### PR TITLE
Solved Issue #32 Fix Copyright year to be dynamic in Contacts card [GSSoC'23]

### DIFF
--- a/components/homepage/Footer/Footer.jsx
+++ b/components/homepage/Footer/Footer.jsx
@@ -90,7 +90,7 @@ const Footer = () => {
                     Devbucket
                   </span>
                   {/* </Link>  */}
-                  2021. All rights reserved
+                  <span> {new Date().getFullYear()}. All rights reserved</span>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Description
 - Fix Copyright year to be dynamic in Contacts Card.
 - Previously the year was hardcoded.

## Related Issue(s)
Closes #32 

## Proposed Changes
 - Added Javascript for always displaying Current year.

## Screenshots (if applicable)
![image](https://github.com/Deveimer/vovoca-frontend/assets/91585213/76bb899d-ba75-4e3b-a8f6-cefa106315cf)


## Checklist

- [X] I have tested the changes locally and they are working as expected.
- [ ] I have added any necessary documentation or updated existing documentation.
- [X] I have reviewed the code changes to ensure they adhere to the project's coding standards.
- [X] I have added appropriate labels to this pull request.